### PR TITLE
Solve issue 75 by adding more information to some exceptions.

### DIFF
--- a/Final.xml
+++ b/Final.xml
@@ -1,0 +1,1 @@
+<mxfile userAgent="Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36" version="7.7.1" editor="www.draw.io" type="github"><diagram>UzV2zq1wL0osyPDNT0nNUTV2VTV2LsrPL4GwciucU3NyVI0MMlNUjV1UjYwMgFjVyA2HrCFY1qAgsSg1rwSLBiADYTaQg2Y1AA==</diagram></mxfile>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -23,12 +23,12 @@
 
             if (true == string.IsNullOrWhiteSpace(request.Scheme))
             {
-                throw new ArgumentException("Http request Scheme is not specified");
+                throw new ArgumentException("Http request Scheme is not specified. This generally occurs because the WebModel for the Request was not properly initialize");
             }
 
             if (false == request.Host.HasValue)
             {
-                throw new ArgumentException("Http request Host is not specified");
+                throw new ArgumentException("Http request Host is not specified. this generally occurs when Host header is not properly declare");
             }
 
             var builder = new StringBuilder();

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensibility/Implementation/Tracing/EventSourceTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensibility/Implementation/Tracing/EventSourceTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensibility.Implement
                 return Activator.CreateInstance(parameter.ParameterType);
             }
 
-            throw new NotSupportedException("Complex types are not suppored");
+            throw new NotSupportedException("The type" + parameterType.GetTypeInfo().Name + "is not supported");
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: [Improve how exception looks like for dnxcore](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/75)
----
###  Geek Gods Collaborators:
- @djob195
- @oemc
- @pvelasquez95
- @kev1260
- @emilioJUA23
- @JaviSolares
---
### Description: 
We listed all possible exceptions ([LIST](https://docs.google.com/spreadsheets/d/1kwLZs9GFtByXGaln08-37oScX7CtUI-bzGijmHhD6lk/edit?usp=sharing)) found on the fork [**gzepeda/ApplicationInsights-aspnetcore**](https://github.com/gzepeda/ApplicationInsights-aspnetcore), and improved some implementations, showing more information on how to resolve the possible exceptions and why they  were thrown.

### Observation:
Unit tests were not implemented because the test was performed by default. 
